### PR TITLE
Fix express server crash

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -245,7 +245,9 @@ async function createHttpServer(listenPort: number) {
       }
     } catch (err) {
       log(`V3 delta error: ${err.message}`);
-      res.sendStatus(400);
+      if (!res.headersSent && !res.writableEnded) {
+        res.sendStatus(400);
+      }
       // Remove building file
       if (buildingFile && fs.existsSync(buildingFile)) fs.rmSync(buildingFile);
     }
@@ -333,7 +335,9 @@ async function createHttpServer(listenPort: number) {
       }
     } catch (err) {
       log(`V2 delta error: ${err.message}`);
-      res.sendStatus(400);
+      if (!res.headersSent && !res.writableEnded) {
+        res.sendStatus(400);
+      }
       // Remove building file
       if (buildingFile && fs.existsSync(buildingFile)) fs.rmSync(buildingFile);
     }


### PR DESCRIPTION
express server hard crashes if delta build (in background) throws error

```
open-balena-delta-delta-1  | [open-balena-delta] V3 delta error: (HTTP code 400) unexpected - invalid reference format 
open-balena-delta-delta-1  | node:internal/errors:496
open-balena-delta-delta-1  |     ErrorCaptureStackTrace(err);
open-balena-delta-delta-1  |     ^
open-balena-delta-delta-1  | 
open-balena-delta-delta-1  | Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
open-balena-delta-delta-1  |     at new NodeError (node:internal/errors:405:5)
open-balena-delta-delta-1  |     at ServerResponse.setHeader (node:_http_outgoing:648:11)
open-balena-delta-delta-1  |     at ServerResponse.header (/usr/src/app/node_modules/express/lib/response.js:794:10)
open-balena-delta-delta-1  |     at ServerResponse.contentType (/usr/src/app/node_modules/express/lib/response.js:624:15)
open-balena-delta-delta-1  |     at ServerResponse.sendStatus (/usr/src/app/node_modules/express/lib/response.js:373:8)
open-balena-delta-delta-1  |     at /usr/src/app/dist/index.js:315:33
open-balena-delta-delta-1  |     at step (/usr/src/app/dist/index.js:56:23)
open-balena-delta-delta-1  |     at Object.throw (/usr/src/app/dist/index.js:37:53)
open-balena-delta-delta-1  |     at rejected (/usr/src/app/dist/index.js:29:65)
open-balena-delta-delta-1  |     at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
open-balena-delta-delta-1  |   code: 'ERR_HTTP_HEADERS_SENT'
open-balena-delta-delta-1  | }
```